### PR TITLE
added '(' and ')' as special characters and address reuse

### DIFF
--- a/FastOlympicCodingHook.py
+++ b/FastOlympicCodingHook.py
@@ -10,7 +10,7 @@ import re
 import time
 
 def decodeStringsOfFile(s):
-    L = ["<", ">", "/", "\\", "|", ":", "\"", "*", "?", ".", "\'"]
+    L = ["<", ">", "/", "\\", "|", ":", "\"", "*", "?", ".", "\'", "(", ")"]
     for i in L:
         s = s.replace(i, "")
     s = re.sub('[^\x00-\xFF\u4e00-\u9fa5]', '', s)
@@ -122,6 +122,7 @@ class CompetitiveCompanionServer:
         HandlerClass = MakeHandlerClassFromFilename()
         global httpd
         httpd = HTTPServer((host, port), HandlerClass)
+        httpd.allow_reuse_address = True
         print("Start server... - ::" + str(port))
         httpd.serve_forever()
         print("Server has been shutdown")


### PR DESCRIPTION
these issues are fixed : 

1. 
/bin/sh: -c: line 0: syntax error near unexpected token `(' /bin/sh: -c: line 0: `g++ '/Users/rajat.shahi/Desktop/comp_pro_arena/Codeforces_-_Codeforces_Round_#855_(Div_3)/C1_Powering_the_Hero_(easy_version).cpp' -std=gnu++20 -o C1_Powering_the_Hero_(easy_version)'

2. 
There was some issue reusing the address.
"File "./python3.3/http/server.py", line 135, in server_bind File "./python3.3/socketserver.py", line 441, in server_bind OSError: [Errno 48] Address already in use"